### PR TITLE
Add updates for themes

### DIFF
--- a/classes/PluginInstall.class.php
+++ b/classes/PluginInstall.class.php
@@ -414,7 +414,7 @@ class PluginInstall
 						for ($x = 1; $x <= $pages; $x++) {
 							$current_page = ($x == $page) ? ' cp-current-page" aria-current="page' : '';
 							$link = '<a href="' . esc_url_raw(add_query_arg(['getpage' => $x], remove_query_arg('getpage'))) . '">' . (int)$x . '</a>';
-							echo '<li class="cp-search-page-item' . esc_html($current_page) . '">' .  wp_kses($link, ['a'=>['href'=>[]]]) . '</li>';
+							echo '<li class="cp-search-page-item' . wp_kses_post($current_page) . '">' . wp_kses_post($link) . '</li>';
 						}
 						?>
 					</ul>

--- a/classes/PluginInstall.class.php
+++ b/classes/PluginInstall.class.php
@@ -344,11 +344,11 @@ class PluginInstall
 ?>
 
 		<div class="wrap plugin-install-tab">
-			<h1 class="wp-heading-inline"><?php _e('Plugins', 'classicpress-directory-integration'); ?></h1>
+			<h1 class="wp-heading-inline"><?php esc_html__('Plugins', 'classicpress-directory-integration'); ?></h1>
 			<hr class="wp-header-end">
 
 			<div class="cp-plugins-page">
-				<h3 class="screen-reader-text"><?php echo esc_html__('Plugins list'); ?></h3>
+				<h3 class="screen-reader-text"><?php echo esc_html__('Plugins list', 'classicpress-directory-integration'); ?></h3>
 				<!-- Search form -->
 				<div class="cp-plugin-search-form">
 					<form method="GET" action="<?php echo esc_url(add_query_arg(['page' => 'classicpress-directory-integration-plugin-install'], remove_query_arg(['getpage']))); ?>">
@@ -393,7 +393,7 @@ class PluginInstall
 										echo '<a href="' . esc_url_raw(wp_nonce_url(add_query_arg(['action' => 'install', 'slug' => $slug]), 'install', '_cpdi')) . '" class="button install-now">' . esc_html__('Install', 'classicpress-directory-integration') . '</a>';
 									}
 									if (array_key_exists($slug, $local_cp_plugins) && $local_cp_plugins[$slug]['Active']) {
-										echo '<span class="cp-plugin-installed">' . esc_html('Installed', 'classicpress-directory-integration') . '</span>';
+										echo '<span class="cp-plugin-installed">' . esc_html__('Installed', 'classicpress-directory-integration') . '</span>';
 									}
 									if (array_key_exists($slug, $local_cp_plugins) && !$local_cp_plugins[$slug]['Active']) {
 										echo '<a href="' . esc_url_raw(wp_nonce_url(add_query_arg(['action' => 'activate', 'slug' => $slug]), 'activate', '_cpdi')) . '" class="button button-primary">' . esc_html__('Activate', 'classicpress-directory-integration') . '</a>';
@@ -414,7 +414,7 @@ class PluginInstall
 						for ($x = 1; $x <= $pages; $x++) {
 							$current_page = ($x == $page) ? ' cp-current-page" aria-current="page' : '';
 							$link = '<a href="' . esc_url_raw(add_query_arg(['getpage' => $x], remove_query_arg('getpage'))) . '">' . (int)$x . '</a>';
-							echo '<li class="cp-search-page-item' . $current_page . '">' . $link . '</li>';
+							echo '<li class="cp-search-page-item' . esc_html($current_page) . '">' .  wp_kses($link, ['a'=>['href'=>[]]]) . '</li>';
 						}
 						?>
 					</ul>

--- a/classes/PluginUpdate.class.php
+++ b/classes/PluginUpdate.class.php
@@ -222,6 +222,11 @@ class PluginUpdate {
 		}
 
 		$dir_data = $this->get_directory_data();
+
+		if (!array_key_exists($slug, $dir_data)) {
+			return;
+		}
+
 		$data     = $dir_data[$slug];
 		$plugin   = $plugins[$slug];
 

--- a/classes/PluginUpdate.class.php
+++ b/classes/PluginUpdate.class.php
@@ -399,6 +399,7 @@ class PluginUpdate {
 			'version'      => $data['Version'],
 			'package'      => $data['Download'],
 			'requires_php' => $data['RequiresPHP'],
+			'requires_cp'  => $data['RequiresCP'],
 			'banners'      => $this->get_plugin_images('banner', $slug),
 			'icons'        => $this->get_plugin_images('icon', $slug),
 

--- a/classes/ThemeUpdate.class.php
+++ b/classes/ThemeUpdate.class.php
@@ -137,6 +137,7 @@ class ThemeUpdate {
 			'version'      => $data['Version'],
 			'package'      => $data['Download'],
 			'requires_php' => $data['RequiresPHP'],
+			'requires_cp'  => $data['RequiresCP'],
 			'url'          => 'https://'.wp_parse_url(\CLASSICPRESS_DIRECTORY_INTEGRATION_URL, PHP_URL_HOST).'/themes/'.$theme_stylesheet,
 		];
 

--- a/classes/ThemeUpdate.class.php
+++ b/classes/ThemeUpdate.class.php
@@ -1,0 +1,150 @@
+<?php
+
+namespace ClassicPress\Directory;
+
+class ThemeUpdate {
+
+	private $cp_themes_directory_data = false;
+	private $cp_themes = false;
+
+	public function __construct() {
+
+		// Hook to check for updates
+		$update_plugins_hook = 'update_themes_'.wp_parse_url(\CLASSICPRESS_DIRECTORY_INTEGRATION_URL, PHP_URL_HOST);
+		add_filter($update_plugins_hook, [$this, 'update_uri_filter'], 10, 4);
+
+		// Hooks to refresh directory data
+		//add_action('activated_plugin', [$this, 'refresh_cp_directory_data']);
+
+	}
+
+	// Get all installed ClassicPress themes
+	private function get_cp_themes() {
+
+		if ($this->cp_themes !== false) {
+			return $this->cp_themes;
+		}
+
+		$all_themes = wp_get_themes();
+		$cp_themes  = [];
+		foreach ($all_themes as $slug => $theme) {
+			if ($theme->display('UpdateURI') === '') {
+				continue;
+			}
+			if (strpos($theme->display('UpdateURI'), \CLASSICPRESS_DIRECTORY_INTEGRATION_URL) !== 0) {
+				continue;
+			}
+			$cp_themes[$slug] = [
+				'WPSlug'      => $slug,
+				'Version'     => $theme->display('UpdateURI'),
+				'RequiresPHP' => $theme->display('RequiresPHP'),
+				'RequiresCP'  => $theme->display('RequiresCP'),
+				'PluginURI'   => $theme->display('PluginURI'),
+			];
+		}
+
+		$this->cp_themes = $cp_themes;
+		return $this->cp_themes;
+
+	}
+
+	// Get data from the directory for all installed ClassicPress themes
+	private function get_directory_data($force = false) {
+
+		// Try to get stored data
+		if (!$force && $this->cp_themes_directory_data !== false) {
+			// We have it in memory
+			return $this->cp_themes_directory_data;
+		}
+		$this->cp_themes_directory_data = get_transient('cpdi_directory_data_themes');
+		if (!$force && $this->cp_themes_directory_data !== false) {
+			// We have it in transient
+			return $this->cp_themes_directory_data;
+		}
+
+		// Query the directory
+		$themes   = $this->get_cp_themes();
+		$endpoint = \CLASSICPRESS_DIRECTORY_INTEGRATION_URL.'themes?byslug='.implode(',', array_keys($themes)).'&_fields=meta';
+		$response = wp_remote_get($endpoint, ['user-agent' => classicpress_user_agent(true)]);
+
+		if (is_wp_error($response) || empty($response['response']) || wp_remote_retrieve_response_code($response) !== 200) {
+			return [];
+		}
+
+		$data_from_dir = json_decode(wp_remote_retrieve_body($response), true);
+		$data = [];
+
+		foreach ($data_from_dir as $single_data) {
+			$data[$single_data['meta']['slug']] = [
+				'Download'        => $single_data['meta']['download_link'],
+				'Version'         => $single_data['meta']['current_version'],
+				'RequiresPHP'     => $single_data['meta']['requires_php'],
+				'RequiresCP'      => $single_data['meta']['requires_cp'],
+				'active_installs' => $single_data['meta']['active_installations'],
+			];
+		}
+
+		$this->cp_themes_directory_data = $data;
+		set_transient('cpdi_directory_data_themes', $this->cp_themes_directory_data, 3 * HOUR_IN_SECONDS);
+		return $this->cp_themes_directory_data;
+
+	}
+
+	// Filter to trigger updates using Update URI header
+	public function update_uri_filter($update, $theme_data, $theme_stylesheet, $locales) {
+
+		// https://developer.wordpress.org/reference/hooks/update_plugins_hostname/
+
+		// Get the slug from Update URI
+		if (preg_match('/themes\?byslug=(.*)/', $theme_data['UpdateURI'], $matches) !== 1) {
+			return false;
+		}
+
+		// Check if the slug matches plugin file
+		if (!isset($matches[1]) || $theme_stylesheet !== $matches[1]) {
+			return false;
+		}
+		$slug = $matches[1];
+
+		// Check if we have that plugin in installed ones
+		$themes  = $this->get_cp_themes();
+
+		if (!array_key_exists($slug, $themes)) {
+			return false;
+		}
+
+		// Check if we have that plugin in directory ones
+		$dir_data = $this->get_directory_data();
+		if (!array_key_exists($slug, $dir_data)) {
+			return false;
+		}
+
+		$theme = $themes[$slug];
+		$data  = $dir_data[$slug];
+
+		if (version_compare($theme['Version'], $data['Version']) >= 0) {
+			// No updates available
+			return false;
+		}
+		if (version_compare(classicpress_version(), $theme['RequiresCP']) === -1) {
+			// Higher CP version required
+			return false;
+		}
+		if (version_compare(phpversion(), $theme['RequiresPHP']) === -1) {
+			// Higher PHP version required
+			return false;
+		}
+
+		$update = [
+			'slug'         => $theme_stylesheet,
+			'version'      => $data['Version'],
+			'package'      => $data['Download'],
+			'requires_php' => $data['RequiresPHP'],
+			'url'          => 'https://'.wp_parse_url(\CLASSICPRESS_DIRECTORY_INTEGRATION_URL, PHP_URL_HOST).'/themes/'.$theme_stylesheet,
+		];
+
+		return $update;
+
+	}
+
+}

--- a/classes/ThemeUpdate.class.php
+++ b/classes/ThemeUpdate.class.php
@@ -13,9 +13,6 @@ class ThemeUpdate {
 		$update_plugins_hook = 'update_themes_'.wp_parse_url(\CLASSICPRESS_DIRECTORY_INTEGRATION_URL, PHP_URL_HOST);
 		add_filter($update_plugins_hook, [$this, 'update_uri_filter'], 10, 4);
 
-		// Hooks to refresh directory data
-		//add_action('activated_plugin', [$this, 'refresh_cp_directory_data']);
-
 	}
 
 	// Get all installed ClassicPress themes
@@ -93,27 +90,27 @@ class ThemeUpdate {
 	// Filter to trigger updates using Update URI header
 	public function update_uri_filter($update, $theme_data, $theme_stylesheet, $locales) {
 
-		// https://developer.wordpress.org/reference/hooks/update_plugins_hostname/
+		// https://developer.wordpress.org/reference/hooks/update_themes_hostname/
 
 		// Get the slug from Update URI
 		if (preg_match('/themes\?byslug=(.*)/', $theme_data['UpdateURI'], $matches) !== 1) {
 			return false;
 		}
 
-		// Check if the slug matches plugin file
+		// Check if the slug matches theme dir
 		if (!isset($matches[1]) || $theme_stylesheet !== $matches[1]) {
 			return false;
 		}
 		$slug = $matches[1];
 
-		// Check if we have that plugin in installed ones
+		// Check if we have that theme in installed ones
 		$themes  = $this->get_cp_themes();
 
 		if (!array_key_exists($slug, $themes)) {
 			return false;
 		}
 
-		// Check if we have that plugin in directory ones
+		// Check if we have that theme in directory ones
 		$dir_data = $this->get_directory_data();
 		if (!array_key_exists($slug, $dir_data)) {
 			return false;

--- a/classicpress-directory-integration.php
+++ b/classicpress-directory-integration.php
@@ -2,17 +2,16 @@
 
 /**
  * -----------------------------------------------------------------------------
- * Plugin Name: ClassicPress Directory Integration
- * Description: Desc.
- * Version: 0.1.0
- * Author: ClassicPress Contributors
- * Author URI: https://www.classicpress.net
- * Plugin URI: https://www.classicpress.net
- * Text Domain: classicpress-directory-integration
- * Domain Path: /languages
- * Requires PHP: 5.6
- * Requires CP: 1.5
- * Update URI: https://directory.classicpress.net/wp-json/wp/v2/plugins?byslug=classicpress-directory-integration
+ * Plugin Name:  ClassicPress Directory Integration
+ * Description:  Install and update plugins from ClassicPress directory and keep ClassicPress themes updated.
+ * Version:      0.1.0
+ * Author:       ClassicPress Contributors
+ * Author URI:   https://www.classicpress.net
+ * Plugin URI:   https://www.classicpress.net
+ * Text Domain:  classicpress-directory-integration
+ * Domain Path:  /languages
+ * Requires PHP: 7.4
+ * Requires CP:  2.0
  * -----------------------------------------------------------------------------
  * This is free software released under the terms of the General Public License,
  * version 2, or later. It is distributed WITHOUT ANY WARRANTY; without even the
@@ -43,7 +42,7 @@ $plugin_install = new PluginInstall();
 
 // Load Theme Update functionality class.
 require_once 'classes/ThemeUpdate.class.php';
-$plugin_update = new ThemeUpdate();
+$theme_update = new ThemeUpdate();
 
 // Register text domain
 function register_text_domain() {

--- a/classicpress-directory-integration.php
+++ b/classicpress-directory-integration.php
@@ -41,6 +41,10 @@ $plugin_update = new PluginUpdate();
 require_once 'classes/PluginInstall.class.php';
 $plugin_install = new PluginInstall();
 
+// Load Theme Update functionality class.
+require_once 'classes/ThemeUpdate.class.php';
+$plugin_update = new ThemeUpdate();
+
 // Register text domain
 function register_text_domain() {
 	load_plugin_textdomain('classicpress-directory-integration', false, dirname(plugin_basename(__FILE__)).'/languages');


### PR DESCRIPTION
Handle updates from ClassicPress Directory for themes as had been done for plugins.

_It was not done before because we needed [this hook](https://developer.wordpress.org/reference/hooks/update_themes_hostname/) that was introduced in ClassicPress v.2._

Also:
- `cpcs` fix
- fix for a warning