### PR TITLE
Create Plugin Modal

### DIFF
--- a/classes/PluginInstall.class.php
+++ b/classes/PluginInstall.class.php
@@ -34,7 +34,7 @@ class PluginInstall
 			return;
 		}
 		wp_enqueue_script( 'classicpress-directory-integration-js-plugin', plugins_url( '../scripts/plugin-page.js', __FILE__ ), array( 'wp-i18n' ), false, true );
-		wp_set_script_translations( 'classicpress-directory-integration-js', 'classicpress-directory-integration', plugin_dir_path( 'classicpress-directory-integration' ) . 'languages' );
+		wp_set_script_translations( 'classicpress-directory-integration-js-plugin', 'classicpress-directory-integration', plugin_dir_path( 'classicpress-directory-integration' ) . 'languages' );
 	}
 
 	public function create_menu()

--- a/classes/PluginInstall.class.php
+++ b/classes/PluginInstall.class.php
@@ -25,7 +25,7 @@ class PluginInstall
 		if ($hook !== $this->page) {
 			return;
 		}
-		wp_enqueue_style('classicpress-directory-integration-css', plugins_url('../styles/plugin-page.css', __FILE__), []);
+		wp_enqueue_style('classicpress-directory-integration-css-plugin', plugins_url('../styles/plugin-page.css', __FILE__), []);
 	}
 
 	public function scripts($hook)
@@ -33,7 +33,7 @@ class PluginInstall
 		if ($hook !== $this->page) {
 			return;
 		}
-		wp_enqueue_script( 'classicpress-directory-integration-js', plugins_url( '../scripts/plugin-page.js', __FILE__ ), array( 'wp-i18n' ), false, true );
+		wp_enqueue_script( 'classicpress-directory-integration-js-plugin', plugins_url( '../scripts/plugin-page.js', __FILE__ ), array( 'wp-i18n' ), false, true );
 		wp_set_script_translations( 'classicpress-directory-integration-js', 'classicpress-directory-integration', plugin_dir_path( 'classicpress-directory-integration' ) . 'languages' );
 	}
 

--- a/classes/PluginInstall.class.php
+++ b/classes/PluginInstall.class.php
@@ -25,7 +25,7 @@ class PluginInstall
 		if ($hook !== $this->page) {
 			return;
 		}
-		wp_enqueue_style('classicpress-directory-integration-css-plugin', plugins_url('../styles/plugin-page.css', __FILE__), []);
+		wp_enqueue_style('classicpress-directory-integration-css', plugins_url('../styles/plugin-page.css', __FILE__), []);
 	}
 
 	public function scripts($hook)
@@ -33,7 +33,8 @@ class PluginInstall
 		if ($hook !== $this->page) {
 			return;
 		}
-		wp_enqueue_script('classicpress-directory-integration-js-plugin', plugins_url('../scripts/plugin-page.js', __FILE__), ['jquery'], false, true);
+		wp_enqueue_script( 'classicpress-directory-integration-js', plugins_url( '../scripts/plugin-page.js', __FILE__ ), array( 'wp-i18n' ), false, true );
+		wp_set_script_translations( 'classicpress-directory-integration-js', 'classicpress-directory-integration', plugin_dir_path( 'classicpress-directory-integration' ) . 'languages' );
 	}
 
 	public function create_menu()
@@ -286,7 +287,7 @@ class PluginInstall
 		$response = $this->do_directory_request($args, 'plugins');
 		if (!$response['success'] || !isset($response['response'][0]['meta']['download_link'])) {
 			// Translators: %1$s is the plugin name.
-			$message = sprintf(esc_html__('API error for plugin %1$s.', 'classicpress-directory-integration'), $local_cp_plugins[$slug]['Name']);
+			$message = sprintf(esc_html__('API error.', 'classicpress-directory-integration'), $local_cp_plugins[$slug]['Name']);
 			$this->add_notice($message, true);
 			$sendback = remove_query_arg(['action', 'slug', '_cpdi'], wp_get_referer());
 			wp_safe_redirect($sendback);
@@ -360,7 +361,7 @@ class PluginInstall
 			<hr class="wp-header-end">
 
 			<div class="cp-plugins-page">
-				<h3 class="screen-reader-text"><?php echo esc_html__('Plugins list', 'classicpress-directory-integration'); ?></h3>
+				<h2 class="screen-reader-text"><?php echo esc_html__('Plugins list', 'classicpress-directory-integration'); ?></h2>
 				<!-- Search form -->
 				<div class="cp-plugin-search-form">
 					<form method="GET" action="<?php echo esc_url(add_query_arg(['page' => 'classicpress-directory-integration-plugin-install'], remove_query_arg(['getpage']))); ?>">
@@ -391,19 +392,19 @@ class PluginInstall
 							<div class="cp-plugin-card-body">
 								<div class="cp-plugin-description"><?php echo wp_kses_post($plugin['excerpt']['rendered']); ?></div>
 							</div>
-							<footer class="cp-plugin-card-footer">
+							<footer class="cp-plugin-card-footer" data-content="<?php echo esc_attr($plugin['content']['rendered']); ?>">
 								<div class="cp-plugin-installs"><?php echo esc_html($plugin['meta']['active_installations'] === '' ? 0 : $plugin['meta']['active_installations']) . esc_html__(' Active Installations', 'classicpress-directory-integration'); ?></div>
 								<div class="cp-plugin-actions">
-									<a href="https://directory.classicpress.net/plugins/<?php echo esc_attr( $slug ); ?>" target="_blank" class="button link-txt"><?php esc_html_e('More Details', 'classicpress-directory-integration'); ?></a>
+									<a href="<?php echo esc_url( admin_url( 'plugin-install.php?tab=plugin-information&plugin=' . $slug . '&TB_iframe=true&width=600&height=550"' ) ); ?>" class="button link-txt"><?php esc_html_e('More Details', 'classicpress-directory-integration'); ?></a>
 									<?php
 									if (!array_key_exists($slug, $local_cp_plugins)) {
-										echo '<a href="' . esc_url_raw(wp_nonce_url(add_query_arg(['action' => 'install', 'slug' => $slug]), 'install', '_cpdi')) . '" class="button install-now">' . esc_html__('Install', 'classicpress-directory-integration') . '</a>';
+										echo '<a href="' . esc_url(wp_nonce_url(add_query_arg(['action' => 'install', 'slug' => $slug]), 'install', '_cpdi')) . '" class="button install-now">' . esc_html__('Install', 'classicpress-directory-integration') . '</a>';
 									}
 									if (array_key_exists($slug, $local_cp_plugins) && $local_cp_plugins[$slug]['Active']) {
-										echo '<span class="button cp-plugin-installed">' . esc_html__('Active', 'classicpress-directory-integration') . '</span>';
+										echo '<span class="button cp-plugin-installed" tabindex="0">' . esc_html__('Active', 'classicpress-directory-integration') . '</span>';
 									}
 									if (array_key_exists($slug, $local_cp_plugins) && !$local_cp_plugins[$slug]['Active']) {
-										echo '<a href="' . esc_url_raw(wp_nonce_url(add_query_arg(['action' => 'activate', 'slug' => $slug]), 'activate', '_cpdi')) . '" class="button button-primary">' . esc_html__('Activate', 'classicpress-directory-integration') . '</a>';
+										echo '<a href="' . esc_url(wp_nonce_url(add_query_arg(['action' => 'activate', 'slug' => $slug]), 'activate', '_cpdi')) . '" class="button button-primary">' . esc_html__('Activate', 'classicpress-directory-integration') . '</a>';
 									}
 									?>
 								</div>
@@ -419,7 +420,7 @@ class PluginInstall
 						<?php
 						for ($x = 1; $x <= $pages; $x++) {
 							$current_page = ($x == $page) ? ' cp-current-page" aria-current="page' : '';
-							$link = '<a href="' . esc_url_raw(add_query_arg(['getpage' => $x], remove_query_arg('getpage'))) . '">' . (int)$x . '</a>';
+							$link = '<a href="' . esc_url(add_query_arg(['getpage' => $x], remove_query_arg('getpage'))) . '">' . (int)$x . '</a>';
 							echo '<li class="cp-search-page-item' . wp_kses_post($current_page) . '">' . wp_kses_post($link) . '</li>';
 						}
 						?>

--- a/classes/PluginInstall.class.php
+++ b/classes/PluginInstall.class.php
@@ -395,7 +395,7 @@ class PluginInstall
 							<footer class="cp-plugin-card-footer" data-content="<?php echo esc_attr($plugin['content']['rendered']); ?>">
 								<div class="cp-plugin-installs"><?php echo esc_html($plugin['meta']['active_installations'] === '' ? 0 : $plugin['meta']['active_installations']) . esc_html__(' Active Installations', 'classicpress-directory-integration'); ?></div>
 								<div class="cp-plugin-actions">
-									<a href="<?php echo esc_url( admin_url( 'plugin-install.php?tab=plugin-information&plugin=' . $slug . '&TB_iframe=true&width=600&height=550"' ) ); ?>" class="button link-txt"><?php esc_html_e('More Details', 'classicpress-directory-integration'); ?></a>
+									<a href="<?php echo esc_url( admin_url( 'plugin-install.php?tab=plugin-information&plugin=' . $slug . '&width=600&height=550"' ) ); ?>" class="button link-txt"><?php esc_html_e('More Details', 'classicpress-directory-integration'); ?></a>
 									<?php
 									if (!array_key_exists($slug, $local_cp_plugins)) {
 										echo '<a href="' . esc_url(wp_nonce_url(add_query_arg(['action' => 'install', 'slug' => $slug]), 'install', '_cpdi')) . '" class="button install-now">' . esc_html__('Install', 'classicpress-directory-integration') . '</a>';

--- a/classes/PluginInstall.class.php
+++ b/classes/PluginInstall.class.php
@@ -395,7 +395,7 @@ class PluginInstall
 							<footer class="cp-plugin-card-footer" data-content="<?php echo esc_attr($plugin['content']['rendered']); ?>">
 								<div class="cp-plugin-installs"><?php echo esc_html($plugin['meta']['active_installations'] === '' ? 0 : $plugin['meta']['active_installations']) . esc_html__(' Active Installations', 'classicpress-directory-integration'); ?></div>
 								<div class="cp-plugin-actions">
-									<a href="<?php echo esc_url( admin_url( 'plugin-install.php?tab=plugin-information&plugin=' . $slug . '&width=600&height=550"' ) ); ?>" class="button link-txt"><?php esc_html_e('More Details', 'classicpress-directory-integration'); ?></a>
+									<a href="<?php echo esc_url( admin_url( 'plugin-install.php?tab=plugin-information&plugin=' . $slug ) ); ?>" class="button link-txt"><?php esc_html_e('More Details', 'classicpress-directory-integration'); ?></a>
 									<?php
 									if (!array_key_exists($slug, $local_cp_plugins)) {
 										echo '<a href="' . esc_url(wp_nonce_url(add_query_arg(['action' => 'install', 'slug' => $slug]), 'install', '_cpdi')) . '" class="button install-now">' . esc_html__('Install', 'classicpress-directory-integration') . '</a>';

--- a/scripts/plugin-page.js
+++ b/scripts/plugin-page.js
@@ -1,3 +1,85 @@
-jQuery(document).ready(function(){
-	console.log('I\'m here');
-});
+/**
+ * @file Functionality for the ClassicPress plugin install screens.
+ */
+document.addEventListener( 'DOMContentLoaded', function() {
+
+	var openers = document.querySelectorAll( '.link-txt' ),
+		width = window.innerWidth,
+		height = window.innerHeight,
+		dialog = document.createElement( 'dialog' ),
+		{ __, _x, _n, _nx } = wp.i18n;	
+
+	dialog.className = 'plugin-details-modal';
+	document.body.append( dialog ); // append dialog element to page
+
+	/**
+	 * Open modal dialog
+	 */
+	openers.forEach( function( opener ) {
+		opener.addEventListener( 'click', function( e ) {
+			var closeButton,
+				header = opener.closest( 'article' ).querySelector( 'h3' ).textContent,
+				content = opener.closest( 'footer' ).dataset.content,
+				status = opener.nextElementSibling,
+				title = opener.closest( 'article' ).querySelector( 'h3' ).textContent ?
+					wp.i18n.sprintf(
+						// translators: %s: Plugin name.
+						wp.i18n.__( 'Plugin: %s' ),
+						opener.closest( 'article' ).querySelector( 'h3' ).textContent
+					) :
+					wp.i18n.__( 'Plugin details' );
+
+			e.preventDefault();
+			e.stopPropagation();
+
+			content = reduceheaders( content );
+			status.id = 'plugin-install-from-modal';
+
+			dialog.showModal();
+			dialog.innerHTML = '<div id="plugin-information" style="width: ' + ( width * 9 / 10 ) + 'px;height: ' + ( height * 9 / 10 ) + 'px;" title="' + title + '"><button type="button" id="dialog-close-button" autofocus><span class="screen-reader-text">' + wp.i18n.__( 'Close' ) + '</span></button><div id="plugin-information-scrollable"><h2>' + header + '</h2>' + content + '<div style="height:60px"></div></div><div id="plugin-information-footer">' + status.outerHTML + '</div></div>';
+
+			// Set initial focus on the "Close" button
+			closeButton = dialog.querySelector( '#dialog-close-button' );
+			closeButton.focus();
+
+			// Remove modal contents using mouse
+			closeButton.addEventListener( 'click', function() {
+				dialog.close();
+				dialog.querySelector( '#plugin-information' ).remove();
+			} );
+
+			// Keyboard interactions
+			dialog.addEventListener( 'keydown', function( e ) {
+				if ( e.key === 'Escape' ) { // Remove modal contents
+					if ( dialog.querySelector( '#directory-item-content' ) !== null ) {
+						dialog.querySelector( '#directory-item-content' ).remove();
+					}
+				}
+				else if ( e.key === 'Enter' && e.target.id === 'dialog-close-button' ) { // Remove modal contents
+					e.preventDefault();
+					dialog.close();
+					if ( dialog.querySelector( '#directory-item-content' ) !== null ) {
+						dialog.querySelector( '#directory-item-content' ).remove();
+					}
+				}
+				else if ( e.key === 'Tab' ) { // Prevent tabbing out of modal
+					if ( e.target.id === status.id && ! e.shiftKey ) {
+						e.preventDefault();
+						closeButton.focus();
+					} else if ( closeButton === e.target && e.shiftKey ) {
+						e.preventDefault();
+						dialog.querySelector( '#' + status.id ).focus();
+					}
+				}
+			} );
+		} );
+	} );
+
+	/**
+	 * Helper function to reduce each element's header level by 1 so that modal header can be an `<h2>`.
+	 */
+	function reduceheaders( content ) {
+		return content.replaceAll( '<h5', '<h6' ).replaceAll( '</h5>', '</h6>' ).replaceAll( '<h4', '<h5' ).replaceAll( '</h4>', '</h5>' ).replaceAll( '<h3', '<h4' ).replaceAll( '</h3>', '</h4>' ).replaceAll( '<h2', '<h3' ).replaceAll( '</h2>', '</h3>' );
+	}
+	
+} );

--- a/styles/plugin-page.css
+++ b/styles/plugin-page.css
@@ -162,6 +162,14 @@
 	font-size: 1.2em;
 }
 
+#plugin-information-scrollable h5 {
+	font-size: 1.1em;
+}
+
+#plugin-information-scrollable h6 {
+	font-size: 1.05em;
+}
+
 .plugin-details-modal #dialog-close-button {
 	border-left: 2px solid #000;
 	border-bottom: 2px solid #000;

--- a/styles/plugin-page.css
+++ b/styles/plugin-page.css
@@ -158,6 +158,10 @@
 	font-size: 2em;
 }
 
+#plugin-information-scrollable h4 {
+	font-size: 1.2em;
+}
+
 .plugin-details-modal #dialog-close-button {
 	border-left: 2px solid #000;
 	border-bottom: 2px solid #000;

--- a/styles/plugin-page.css
+++ b/styles/plugin-page.css
@@ -76,7 +76,9 @@
 }
 
 .cp-plugin-actions .button:hover,
-.cp-plugin-actions .button:focus {
+.cp-plugin-actions .button:focus,
+#plugin-install-from-modal.button:hover,
+#plugin-install-from-modal.button:focus {
 	color: #fff;
 	background-color: #2271b1;
 	border-color: #185281;
@@ -140,6 +142,41 @@
 
 .cp-plugins-pagination li:not(:first-child) a {
     margin-left: -1px;
+}
+
+#plugin-information {
+	max-width: 800px;
+	margin: auto;
+	border: 2px solid #000;
+}
+
+#plugin-information-scrollable {
+	padding: 0 1.5em;
+}
+
+#plugin-information-scrollable h2 {
+	font-size: 2em;
+}
+
+.plugin-details-modal #dialog-close-button {
+	border-left: 2px solid #000;
+	border-bottom: 2px solid #000;
+}
+
+.plugin-details-modal #dialog-close-button:hover,
+.plugin-details-modal #dialog-close-button:focus {
+	background-color: #fafafa;
+}
+
+#plugin-install-from-modal {
+	float: right;
+	margin-top: -2px;
+}
+
+#plugin-information-footer .cp-plugin-installed {
+	color: #fff;
+	border: 1px solid #269126;
+	background-color: #269126;
 }
 
 @media (min-width: 783px) {


### PR DESCRIPTION
This PR creates a modal dialog for when the "More Details" link is clicked on the CP Plugins page.

In order to make this easier to add to core in future, I have tried, as much as possible, to use CSS class names and styles that CP already uses in the back-end. I have also followed the rules we use for core JavaScript, which is why I have used `var` instead of `const` and `let`.

One thing I am not sure about is whether I have used `wp_set_script_translations` correctly on line 37 of `PluginInstall.class.php`.