### PR TITLE
Enable Modal for Themes

### DIFF
--- a/classes/PluginInstall.class.php
+++ b/classes/PluginInstall.class.php
@@ -384,7 +384,7 @@ class PluginInstall
 					foreach ( $plugins as $plugin ) {
 						$slug = $plugin['meta']['slug'];
 						$content = $plugin['content']['rendered'];
-						$markdown_contents = cp_get_markdown_plugin_contents( $content, '<div class="markdown-heading">', '</div>' );
+						$markdown_contents = cp_get_markdown_contents( $content, '<div class="markdown-heading">', '</div>' );
 						foreach ( $markdown_contents as $markdown_content ) {
 							$content = str_replace( '<div class="markdown-heading">' . $markdown_content . '</div>', $markdown_content, $content );
 						}
@@ -470,7 +470,7 @@ class PluginInstallSkin extends \Plugin_Installer_Skin
  *
  * See https://stackoverflow.com/a/27078384
  */
-function cp_get_markdown_plugin_contents( $str, $startDelimiter, $endDelimiter ) {
+function cp_get_markdown_contents( $str, $startDelimiter, $endDelimiter ) {
 	$contents = [];
 	$startDelimiterLength = strlen( $startDelimiter );
 	$endDelimiterLength = strlen( $endDelimiter );


### PR DESCRIPTION
This PR enables the use of a modal for themes. I have also changed a function name in `PluginInstall.class.php` to reflect the fact that I use the same function for themes.

I have NOT included a CSS or JS file here because I tried duplicating `plugin-page.js` and `plugin-page.css` for themes and they both worked perfectly without me changing anything. So I wanted to ask whether you still want me to add both files, or whether you might instead just rename `plugin-page.js` and `plugin-page.css` and use them for both plugins and themes. 