### PR TITLE
Add filter for plugin images folder `cpdi_images_folder_{$plugin}`

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,18 @@ Steps
 ## WP-CLI commands
 
 - Flush transients: `wp cpdi flush`
+
+## Hooks
+
+#### `apply_filters( "cpdi_images_folder_{$plugin}", string $folder )`
+Filters the folder where we search for icons and banners.
+The filtered path is relative to the plugin's directory.
+
+Example:
+```php
+add_filter(
+	'cpdi_images_folder_' . basename( __DIR__ ),
+	function ( $source ) {
+		return '/assets/images';
+	}
+);


### PR DESCRIPTION
This plugin searches for icons and banners in the `images` folder inside the plugin folder.
As a plugin author can freely organize where to put those images, the filter let plugins developers change the default location.

`apply_filters( "cpdi_images_folder_{$plugin}", string $folder )`

## Example:
```php
add_filter(
	'cpdi_images_folder_' . basename( __DIR__ ),
	function ( $source ) {
		return '/assets/images';
	}
);
```

## Screenshots
# Before
<img width="747" alt="image" src="https://github.com/ClassicPress/classicpress-directory-integration/assets/29772709/cdb6c1e1-efb1-42f7-85c5-f41287588a33">

# After

<img width="741" alt="image" src="https://github.com/ClassicPress/classicpress-directory-integration/assets/29772709/a9991ec5-4738-4d8f-b13c-49696d82e0b8">
