### PR TITLE
Reinstate correct target for "More Details" hyperlink when JavaScript is disabled

### DIFF
--- a/classes/PluginInstall.class.php
+++ b/classes/PluginInstall.class.php
@@ -401,7 +401,7 @@ class PluginInstall
 							<footer class="cp-plugin-card-footer" data-content="<?php echo esc_attr( $content ); ?>">
 								<div class="cp-plugin-installs"><?php echo esc_html($plugin['meta']['active_installations'] === '' ? 0 : $plugin['meta']['active_installations']) . esc_html__(' Active Installations', 'classicpress-directory-integration'); ?></div>
 								<div class="cp-plugin-actions">
-									<a href="<?php echo esc_url( admin_url( 'plugin-install.php?tab=plugin-information&plugin=' . $slug ) ); ?>" class="button link-txt"><?php esc_html_e('More Details', 'classicpress-directory-integration'); ?></a>
+									<a href="https://directory.classicpress.net/plugins/<?php echo esc_attr( $slug ); ?>" target="_blank" class="button link-txt"><?php esc_html_e('More Details', 'classicpress-directory-integration'); ?></a>
 									<?php
 									if (!array_key_exists($slug, $local_cp_plugins)) {
 										echo '<a href="' . esc_url(wp_nonce_url(add_query_arg(['action' => 'install', 'slug' => $slug]), 'install', '_cpdi')) . '" class="button install-now">' . esc_html__('Install', 'classicpress-directory-integration') . '</a>';

--- a/classes/ThemeInstall.class.php
+++ b/classes/ThemeInstall.class.php
@@ -387,7 +387,7 @@ class ThemeInstall
 							<footer class="cp-plugin-card-footer" data-content="<?php echo esc_attr( $content ); ?>">
 								<div class="cp-plugin-installs"><?php echo esc_html($theme['meta']['active_installations'] === '' ? 0 : $theme['meta']['active_installations']) . esc_html__(' Active Installations', 'classicpress-directory-integration'); ?></div>
 								<div class="cp-plugin-actions">
-									<a href="<?php echo esc_url( admin_url( 'themes.php?tab=theme-information&theme=' . $slug ) ); ?>" class="button link-txt"><?php esc_html_e('More Details', 'classicpress-directory-integration'); ?></a>
+									<a href="https://directory.classicpress.net/themes/<?php echo esc_attr( $slug ); ?>" target="_blank" class="button link-txt"><?php esc_html_e('More Details', 'classicpress-directory-integration'); ?></a>
 									<?php
 									if (!array_key_exists($slug, $local_cp_themes)) {
 										echo '<a href="' . esc_url(wp_nonce_url(add_query_arg(['action' => 'install', 'slug' => $slug]), 'install', '_cpdi')) . '" class="button install-now">' . esc_html__('Install', 'classicpress-directory-integration') . '</a>';


### PR DESCRIPTION
I changed them in a previous PR when I should not have done. This PR reverts those changes so that the links will work when JavaScript is disabled.