### PR TITLE
Change display for plugins and themes passing `cpcs`

### DIFF
--- a/classes/PluginInstall.class.php
+++ b/classes/PluginInstall.class.php
@@ -391,14 +391,16 @@ class PluginInstall
 					foreach ( $plugins as $plugin ) {
 						$slug = $plugin['meta']['slug'];
 						$content = $plugin['content']['rendered'];
+						$vetted = $plugin['meta']['cpcs_status'] === 'passing' ? '<span class="dashicons dashicons-shield"></span>' : '';
+						$vetted_article = $plugin['meta']['cpcs_status'] === 'passing' ? ' vetted-plugin' : '';
 						$markdown_contents = self::get_markdown_contents( $content, '<div class="markdown-heading">', '</div>' );
 						foreach ( $markdown_contents as $markdown_content ) {
 							$content = str_replace( '<div class="markdown-heading">' . $markdown_content . '</div>', $markdown_content, $content );
 						}
 					?>
-						<article class="cp-plugin-card" id="cp-plugin-id-<?php echo esc_attr($slug); ?>">
+						<article class="cp-plugin-card<?php echo esc_attr($vetted_article); ?>" id="cp-plugin-id-<?php echo esc_attr($slug); ?>">
 							<header class="cp-plugin-card-header">
-								<h3><?php echo esc_html($plugin['title']['rendered']); ?></h3>
+								<h3><?php echo esc_html($plugin['title']['rendered']); echo wp_kses_post($vetted); ?></h3>
 								<div class="cp-plugin-author"><?php echo wp_kses(sprintf(__('By <b>%1$s</b>.', 'classicpress-directory-integration'), $plugin['meta']['developer_name']), ['b' => []]); ?></div>
 							</header>
 							<div class="cp-plugin-card-body">

--- a/classes/ThemeInstall.class.php
+++ b/classes/ThemeInstall.class.php
@@ -388,14 +388,16 @@ class ThemeInstall
 					foreach ($themes as $theme) {
 						$slug = $theme['meta']['slug'];
 						$content = $theme['content']['rendered'];
+						$vetted = $theme['meta']['cpcs_status'] === 'passing' ? '<span class="vetted-theme dashicons dashicons-shield"></span>' : '';
+						$vetted_article = $theme['meta']['cpcs_status'] === 'passing' ? ' vetted-theme' : '';
 						$markdown_contents = self::get_markdown_contents( $content, '<div class="markdown-heading">', '</div>' );
 						foreach ( $markdown_contents as $markdown_content ) {
 							$content = str_replace( '<div class="markdown-heading">' . $markdown_content . '</div>', $markdown_content, $content );
 						}
 					?>
-						<article class="cp-plugin-card" id="cp-plugin-id-<?php echo esc_attr($slug); ?>">
+						<article class="cp-plugin-card<?php echo esc_attr($vetted_article); ?>" id="cp-plugin-id-<?php echo esc_attr($slug); ?>">
 							<header class="cp-plugin-card-header">
-								<h3><?php echo esc_html($theme['title']['rendered']); ?></h3>
+								<h3><?php echo esc_html($theme['title']['rendered']); echo wp_kses_post($vetted); ?></h3>
 								<div class="cp-plugin-author"><?php echo wp_kses(sprintf(__('By <b>%1$s</b>.', 'classicpress-directory-integration'), $theme['meta']['developer_name']), ['b' => []]); ?></div>
 							</header>
 							<div class="cp-plugin-card-body">

--- a/styles/directory-integration.css
+++ b/styles/directory-integration.css
@@ -184,6 +184,17 @@
 	background-color: #fafafa;
 }
 
+.vetted-plugin .dashicons,
+.vetted-theme .dashicons{
+	float: right;
+	color: #057f99;
+}
+
+.vetted-plugin,
+.vetted-theme {
+	background-color: #EBF4F7;
+}
+
 #plugin-install-from-modal {
 	float: right;
 	margin-top: -2px;


### PR DESCRIPTION
I've added `cpcs_status` to plugin and theme CPT.
It contains `passed` if `cpcs` is passing.
Also added the meta to REST API.

This PR is a draft that uses this new information to give more prestige to plugins/themes having a passing `cpcs` GitHub workflow. 

Colors and icon chan be changed and it misses a11y and explanation.

<img width="1133" alt="image" src="https://github.com/ClassicPress/classicpress-directory-integration/assets/29772709/7f05aea6-65b9-4991-9193-6447b43eaeca">
<img width="1136" alt="image" src="https://github.com/ClassicPress/classicpress-directory-integration/assets/29772709/c203f431-fa23-48d8-825a-e0bf29664a53">


