### PR TITLE
Stop working if on WordPress

### DIFF
--- a/classicpress-directory-integration.php
+++ b/classicpress-directory-integration.php
@@ -37,15 +37,15 @@ if(!function_exists('classicpress_version')) {
 }
 
 function deactivate_plugin_now() {
-    if ( is_plugin_active( 'classicpress-directory-integration/classicpress-directory-integration.php' ) ) {
-        deactivate_plugins( 'classicpress-directory-integration/classicpress-directory-integration.php' );
+    if (is_plugin_active('classicpress-directory-integration/classicpress-directory-integration.php')) {
+        deactivate_plugins('classicpress-directory-integration/classicpress-directory-integration.php');
     }
 }
 
 function error_is_wp () {
     $class = 'notice notice-error';
-    $message = __( 'ClassicPress Directory Integration can\'t work on WordPress', 'classicpress-directory-integration' );
-    printf( '<div class="%1$s"><p>%2$s</p></div>', $class, $message );
+    $message = __('ClassicPress Directory Integration can\'t work on WordPress', 'classicpress-directory-integration');
+    printf('<div class="%1$s"><p>%2$s</p></div>', $class, $message);
 }
 
 const DB_VERSION = 1;

--- a/classicpress-directory-integration.php
+++ b/classicpress-directory-integration.php
@@ -4,7 +4,7 @@
  * -----------------------------------------------------------------------------
  * Plugin Name:  ClassicPress Directory Integration
  * Description:  Install and update plugins and themes from ClassicPress directory.
- * Version:      1.1.1
+ * Version:      1.1.2
  * Author:       ClassicPress Contributors
  * Author URI:   https://www.classicpress.net
  * Plugin URI:   https://www.classicpress.net
@@ -26,6 +26,26 @@ namespace ClassicPress\Directory;
 // Prevent direct access.
 if (!defined('ABSPATH')) {
 	die();
+}
+
+// Bail if on WordPress
+if(!function_exists('classicpress_version')) {
+    add_action('admin_init', 'ClassicPress\Directory\deactivate_plugin_now');
+    add_action('admin_notices', 'ClassicPress\Directory\error_is_wp');
+    unset($_GET['activate']);
+    return;
+}
+
+function deactivate_plugin_now() {
+    if ( is_plugin_active( 'classicpress-directory-integration/classicpress-directory-integration.php' ) ) {
+        deactivate_plugins( 'classicpress-directory-integration/classicpress-directory-integration.php' );
+    }
+}
+
+function error_is_wp () {
+    $class = 'notice notice-error';
+    $message = __( 'ClassicPress Directory Integration can\'t work on WordPress', 'classicpress-directory-integration' );
+    printf( '<div class="%1$s"><p>%2$s</p></div>', $class, $message );
 }
 
 const DB_VERSION = 1;


### PR DESCRIPTION
Since the plugin uses ClassicPress functions and also rely heavily on our customization of the Update URI, deactivate the plugin if ClassicPress is not detected.

<img width="723" alt="image" src="https://github.com/user-attachments/assets/c399e5d7-2c8a-4f16-9b58-33a3cc32dd1a" />