### PR TITLE
Show results from page 1 when performing a new search

### DIFF
--- a/classes/PluginInstall.class.php
+++ b/classes/PluginInstall.class.php
@@ -161,8 +161,16 @@ class PluginInstall
 
 		$e = wp_remote_retrieve_response_code($response);
 		if ($e !== 200) {
-			$result['error'] = $response['response']['message'];
+			$result['error'] = $response['response']['message'].'.';
 			$result['code']  = $response['response']['code'];
+			if (!isset($response['body']) || !json_validate($response['body'])) {
+				return $result;
+			}
+			$api_message = json_decode($response['body'], true);
+			if(!isset($api_message['message'])) {
+				return $result;
+			}
+			$result['error'] .= ' '.$api_message['message'];
 			return $result;
 		}
 

--- a/classes/PluginInstall.class.php
+++ b/classes/PluginInstall.class.php
@@ -356,6 +356,7 @@ class PluginInstall
 		if (isset($_REQUEST['searchingfor']) && $_REQUEST['searchingfor'] !== $searching) { //phpcs:ignore WordPress.Security.NonceVerification.Recommended
 			$args['page'] = 1;
 		}
+
 		$result = $this->do_directory_request($args);
 		if ($result['success'] === false) {
 			// Query failed, display errors and exit.

--- a/classes/PluginInstall.class.php
+++ b/classes/PluginInstall.class.php
@@ -385,7 +385,7 @@ class PluginInstall
 					<p class="cp-plugin-search-box">
 						<label for="searchfor" class="screen-reader-text" ><?php echo esc_html__('Search for plugins', 'classicpress-directory-integration'); ?></label><br>
 						<input type="hidden" name="searchingfor" value="<?php echo esc_html($searching); ?>">
-						<input type="text" id="searchfor" name="searchfor" class="wp-filter-search" placeholder="<?php echo esc_html__('Search for a plugin...', 'classicpress-directory-integration'); ?>"><br>
+						<input type="search" id="searchfor" name="searchfor" class="wp-filter-search" <?php echo $searching !== '' ? 'value="'.esc_html($searching).'" ' : '' ?>placeholder="<?php echo esc_html__('Search for a plugin...', 'classicpress-directory-integration'); ?>"><br>
 						<?php
 						foreach ((array) $_GET as $key => $val) { //phpcs:ignore WordPress.Security.NonceVerification.Recommended
 							if (in_array($key, ['searchfor', 'getpage'])) {

--- a/classes/PluginInstall.class.php
+++ b/classes/PluginInstall.class.php
@@ -351,7 +351,11 @@ class PluginInstall
 		if (isset($_REQUEST['searchfor'])) { //phpcs:ignore WordPress.Security.NonceVerification.Recommended
 			$args['search'] = sanitize_text_field(wp_unslash($_REQUEST['searchfor'])); //phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		}
-
+		// Reset paginations for new searches
+		$searching = $args['search'] ?? '';
+		if (isset($_REQUEST['searchingfor']) && $_REQUEST['searchingfor'] !== $searching) { //phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			$args['page'] = 1;
+		}
 		$result = $this->do_directory_request($args);
 		if ($result['success'] === false) {
 			// Query failed, display errors and exit.
@@ -379,10 +383,11 @@ class PluginInstall
 				<form method="GET" action="<?php echo esc_url(add_query_arg(['page' => 'classicpress-directory-integration-plugin-install'], remove_query_arg(['getpage']))); ?>">
 					<p class="cp-plugin-search-box">
 						<label for="searchfor" class="screen-reader-text" ><?php echo esc_html__('Search for plugins', 'classicpress-directory-integration'); ?></label><br>
+						<input type="hidden" name="searchingfor" value="<?php echo esc_html($searching); ?>">
 						<input type="text" id="searchfor" name="searchfor" class="wp-filter-search" placeholder="<?php echo esc_html__('Search for a plugin...', 'classicpress-directory-integration'); ?>"><br>
 						<?php
 						foreach ((array) $_GET as $key => $val) { //phpcs:ignore WordPress.Security.NonceVerification.Recommended
-							if (in_array($key, ['searchfor'])) {
+							if (in_array($key, ['searchfor', 'getpage'])) {
 								continue;
 							}
 							echo '<input type="hidden" name="' . esc_attr($key) . '" value="' . esc_html($val) . '" />';

--- a/classes/ThemeInstall.class.php
+++ b/classes/ThemeInstall.class.php
@@ -382,7 +382,7 @@ class ThemeInstall
 					<p class="cp-plugin-search-box">
 						<label for="searchfor" class="screen-reader-text"><?php echo esc_html__('Search for a theme', 'classicpress-directory-integration'); ?></label><br>
 						<input type="hidden" name="searchingfor" value="<?php echo esc_html($searching); ?>">
-						<input type="text" id="searchfor" name="searchfor" class="wp-filter-search" placeholder="<?php echo esc_html__('Search for a theme...', 'classicpress-directory-integration'); ?>"><br>
+						<input type="search" id="searchfor" name="searchfor" class="wp-filter-search" <?php echo $searching !== '' ? 'value="'.esc_html($searching).'" ' : '' ?>placeholder="<?php echo esc_html__('Search for a theme...', 'classicpress-directory-integration'); ?>"><br>
 						<?php
 						foreach ((array) $_GET as $key => $val) { //phpcs:ignore WordPress.Security.NonceVerification.Recommended
 							if (in_array($key, ['searchfor', 'getpage'])) {

--- a/classicpress-directory-integration.php
+++ b/classicpress-directory-integration.php
@@ -4,7 +4,7 @@
  * -----------------------------------------------------------------------------
  * Plugin Name:  ClassicPress Directory Integration
  * Description:  Install and update plugins and themes from ClassicPress directory.
- * Version:      1.1.2
+ * Version:      1.1.3
  * Author:       ClassicPress Contributors
  * Author URI:   https://www.classicpress.net
  * Plugin URI:   https://www.classicpress.net


### PR DESCRIPTION
As spotted on the [forum](https://forums.classicpress.net/t/400-bad-request-when-searching-cp-directory-integration/6123) when a text search is performed the page is not reset to 1.
This lead to a 400 error.

This PR also adds more informations to the error message.

<img width="620" alt="image" src="https://github.com/user-attachments/assets/8260d276-1147-4138-bbf9-e43e9d7cdaee" />

## Before:
- Select "Install CP Plugin" from "Plugin" menu
- Navigate to page 7
- Search for "Security"
- "No plugins found" error is shown among  "Bad Request (400)" ❌
- Search for "Classic"
- Notice that the current page is now 7 of 7 ❌
- Search for "klsretmgmsrb"
- Notice that only "No plugins found" error is shown. ✅

## Testing:
- Select "Install CP Plugin" from "Plugin" menu
- Navigate to page 7
- Search for "Security"
- Notice that the current page is now 1 of 4 ✅
- Move to page 2
- Search for "Securit"
- Notice that the current page is now 1 of 4 ✅
- Search for "klsretmgmsrb"
- Notice that only "No plugins found" error is shown.  ✅
