### PR TITLE
Polyfill `json_validate` that is not defined in PHP <8.3

### DIFF
--- a/classes/class-plugin-install.php
+++ b/classes/class-plugin-install.php
@@ -156,7 +156,7 @@ class PluginInstall {
 		if ( $e !== 200 ) {
 			$result['error'] = $response['response']['message'] . '.';
 			$result['code']  = $response['response']['code'];
-			if ( ! isset( $response['body'] ) || ! json_validate( $response['body'] ) ) {
+			if ( ! isset( $response['body'] ) || ! self::json_validate( $response['body'] ) ) {
 				return $result;
 			}
 			$api_message = json_decode( $response['body'], true );

--- a/classes/class-theme-install.php
+++ b/classes/class-theme-install.php
@@ -149,7 +149,7 @@ class ThemeInstall {
 		if ( $e !== 200 ) {
 			$result['error'] = $response['response']['message'] . '.';
 			$result['code']  = $response['response']['code'];
-			if ( ! isset( $response['body'] ) || ! json_validate( $response['body'] ) ) {
+			if ( ! isset( $response['body'] ) || ! self::json_validate( $response['body'] ) ) {
 				return $result;
 			}
 			$api_message = json_decode( $response['body'], true );

--- a/classes/trait-helpers.php
+++ b/classes/trait-helpers.php
@@ -37,7 +37,7 @@ trait Helpers {
 	 * The function is defined only in PHP 8 >= 8.3.0
 	 */
 	private static function json_validate( $json ) {
-		if ( function_exists( 'json_validate') ) {
+		if ( function_exists( 'json_validate' ) ) {
 			return json_validate( $json );
 		}
 		return json_decode( $json ) !== null;

--- a/classes/trait-helpers.php
+++ b/classes/trait-helpers.php
@@ -4,7 +4,6 @@ namespace ClassicPress\Directory;
 
 trait Helpers {
 
-
 	/**
 	 * Get all substrings within text that are found between two other, specified strings
 	 *
@@ -32,4 +31,16 @@ trait Helpers {
 
 		return $contents;
 	}
+
+	/**
+	 * Polyfill for json_validate
+	 * The function is defined only in PHP 8 >= 8.3.0
+	 */
+	private static function json_validate( $json ) {
+		if ( function_exists( 'json_validate') ) {
+			return json_validate( $json );
+		}
+		return json_decode( $json ) !== null;
+	}
+
 }

--- a/classicpress-directory-integration.php
+++ b/classicpress-directory-integration.php
@@ -4,7 +4,7 @@
  * -----------------------------------------------------------------------------
  * Plugin Name:  ClassicPress Directory Integration
  * Description:  Install and update plugins and themes from ClassicPress directory.
- * Version:      1.1.3
+ * Version:      1.1.4
  * Author:       ClassicPress Contributors
  * Author URI:   https://www.classicpress.net
  * Plugin URI:   https://www.classicpress.net


### PR DESCRIPTION
Use own method `json_validate` that is a polyfill for [json_validate](https://www.php.net/manual/en/function.json-validate.php).

Closes #36.