### PR TITLE
Updated search form and modal

### DIFF
--- a/classes/class-plugin-install.php
+++ b/classes/class-plugin-install.php
@@ -376,9 +376,9 @@ class PluginInstall {
 			<div class="cp-plugin-search-form">
 				<form method="GET" action="<?php echo esc_url( add_query_arg( array( 'page' => 'classicpress-directory-integration-plugin-install' ), remove_query_arg( array( 'getpage' ) ) ) ); ?>">
 					<p class="cp-plugin-search-box">
-						<label for="searchfor" class="screen-reader-text" ><?php echo esc_html__( 'Search for plugins', 'classicpress-directory-integration' ); ?></label><br>
+						<label for="searchfor" class="screen-reader-text" ><?php echo esc_html__( 'Search for plugins', 'classicpress-directory-integration' ); ?></label>
 						<input type="hidden" name="searchingfor" value="<?php echo esc_html( $searching ); ?>">
-						<input type="search" id="searchfor" name="searchfor" class="wp-filter-search" <?php echo $searching !== '' ? 'value="' . esc_html( $searching ) . '" ' : ''; ?>placeholder="<?php echo esc_html__( 'Search for a plugin...', 'classicpress-directory-integration' ); ?>"><br>
+						<input type="search" id="searchfor" name="searchfor" class="wp-filter-search" <?php echo $searching !== '' ? 'value="' . esc_html( $searching ) . '" ' : ''; ?>placeholder="<?php echo esc_html__( 'Search for a plugin...', 'classicpress-directory-integration' ); ?>">
 						<?php
 						foreach ( (array) $_GET as $key => $val ) { //phpcs:ignore WordPress.Security.NonceVerification.Recommended
 							if ( in_array( $key, array( 'searchfor', 'getpage', 'searchingfor' ) ) ) {

--- a/classes/class-plugin-install.php
+++ b/classes/class-plugin-install.php
@@ -375,7 +375,7 @@ class PluginInstall {
 			<!-- Search form -->
 			<div class="cp-plugin-search-form">
 				<form method="GET" action="<?php echo esc_url( add_query_arg( array( 'page' => 'classicpress-directory-integration-plugin-install' ), remove_query_arg( array( 'getpage' ) ) ) ); ?>">
-					<p class="cp-plugin-search-box">
+					<fieldset class="cp-plugin-search-box">
 						<label for="searchfor" class="screen-reader-text" ><?php echo esc_html__( 'Search for plugins', 'classicpress-directory-integration' ); ?></label>
 						<input type="hidden" name="searchingfor" value="<?php echo esc_html( $searching ); ?>">
 						<input type="search" id="searchfor" name="searchfor" class="wp-filter-search" <?php echo $searching !== '' ? 'value="' . esc_html( $searching ) . '" ' : ''; ?>placeholder="<?php echo esc_html__( 'Search for a plugin...', 'classicpress-directory-integration' ); ?>">
@@ -387,7 +387,7 @@ class PluginInstall {
 							echo '<input type="hidden" name="' . esc_attr( $key ) . '" value="' . esc_html( $val ) . '" />';
 						}
 						?>
-					</p>
+					</fieldset>
 				</form>
 			</div>
 			<hr class="wp-header-end">

--- a/classes/class-theme-install.php
+++ b/classes/class-theme-install.php
@@ -368,9 +368,9 @@ class ThemeInstall {
 			<div class="cp-plugin-search-form">
 				<form method="GET" action="<?php echo esc_url( add_query_arg( array( 'page' => 'classicpress-directory-integration-theme-install' ), remove_query_arg( array( 'getpage' ) ) ) ); ?>">
 					<p class="cp-plugin-search-box">
-						<label for="searchfor" class="screen-reader-text"><?php echo esc_html__( 'Search for a theme', 'classicpress-directory-integration' ); ?></label><br>
+						<label for="searchfor" class="screen-reader-text"><?php echo esc_html__( 'Search for a theme', 'classicpress-directory-integration' ); ?></label>
 						<input type="hidden" name="searchingfor" value="<?php echo esc_html( $searching ); ?>">
-						<input type="search" id="searchfor" name="searchfor" class="wp-filter-search" <?php echo $searching !== '' ? 'value="' . esc_html( $searching ) . '" ' : ''; ?>placeholder="<?php echo esc_html__( 'Search for a theme...', 'classicpress-directory-integration' ); ?>"><br>
+						<input type="search" id="searchfor" name="searchfor" class="wp-filter-search" <?php echo $searching !== '' ? 'value="' . esc_html( $searching ) . '" ' : ''; ?>placeholder="<?php echo esc_html__( 'Search for a theme...', 'classicpress-directory-integration' ); ?>">
 						<?php
 						foreach ( (array) $_GET as $key => $val ) { //phpcs:ignore WordPress.Security.NonceVerification.Recommended
 							if ( in_array( $key, array( 'searchfor', 'getpage', 'searchingfor' ) ) ) {

--- a/classes/class-theme-install.php
+++ b/classes/class-theme-install.php
@@ -191,7 +191,7 @@ class ThemeInstall {
 		$notice        = $other_notices === false ? '' : $other_notices;
 		$failure_style = $failure ? 'notice-error' : 'notice-success';
 		$notice       .= '<div class="notice ' . $failure_style . ' is-dismissible">';
-		$notice       .= '    >' . esc_html( $message ) . '</p>';
+		$notice       .= '    <p>' . esc_html( $message ) . '</p>';
 		$notice       .= '</div>';
 		set_transient( 'cpdi_ti_notices', $notice, \HOUR_IN_SECONDS );
 	}

--- a/classes/class-theme-install.php
+++ b/classes/class-theme-install.php
@@ -191,7 +191,7 @@ class ThemeInstall {
 		$notice        = $other_notices === false ? '' : $other_notices;
 		$failure_style = $failure ? 'notice-error' : 'notice-success';
 		$notice       .= '<div class="notice ' . $failure_style . ' is-dismissible">';
-		$notice       .= '    <p>' . esc_html( $message ) . '</p>';
+		$notice       .= '    >' . esc_html( $message ) . '</p>';
 		$notice       .= '</div>';
 		set_transient( 'cpdi_ti_notices', $notice, \HOUR_IN_SECONDS );
 	}
@@ -367,7 +367,7 @@ class ThemeInstall {
 			<!-- Search form -->
 			<div class="cp-plugin-search-form">
 				<form method="GET" action="<?php echo esc_url( add_query_arg( array( 'page' => 'classicpress-directory-integration-theme-install' ), remove_query_arg( array( 'getpage' ) ) ) ); ?>">
-					<p class="cp-plugin-search-box">
+					<fieldset class="cp-plugin-search-box">
 						<label for="searchfor" class="screen-reader-text"><?php echo esc_html__( 'Search for a theme', 'classicpress-directory-integration' ); ?></label>
 						<input type="hidden" name="searchingfor" value="<?php echo esc_html( $searching ); ?>">
 						<input type="search" id="searchfor" name="searchfor" class="wp-filter-search" <?php echo $searching !== '' ? 'value="' . esc_html( $searching ) . '" ' : ''; ?>placeholder="<?php echo esc_html__( 'Search for a theme...', 'classicpress-directory-integration' ); ?>">
@@ -379,7 +379,7 @@ class ThemeInstall {
 							echo '<input type="hidden" name="' . esc_attr( $key ) . '" value="' . esc_html( $val ) . '" />';
 						}
 						?>
-					</p>
+					</fieldset>
 				</form>
 			</div>
 			<hr class="wp-header-end">

--- a/scripts/directory-integration.js
+++ b/scripts/directory-integration.js
@@ -36,7 +36,7 @@ document.addEventListener( 'DOMContentLoaded', function() {
 			status.id = 'plugin-install-from-modal';
 
 			dialog.showModal();
-			dialog.innerHTML = '<div id="plugin-information" style="width: ' + ( width * 9 / 10 ) + 'px;height: ' + ( height * 9 / 10 ) + 'px;" title="' + title + '"><button type="button" id="dialog-close-button" autofocus><span class="screen-reader-text">' + wp.i18n.__( 'Close' ) + '</span></button><div id="plugin-information-scrollable"><h2>' + header + '</h2>' + content + '<div style="height:60px"></div></div><div id="plugin-information-footer">' + status.outerHTML + '</div></div>';
+			dialog.innerHTML = '<div id="plugin-information" style="width: ' + ( width * 9 / 10 ) + 'px;height: ' + ( height * 9 / 10 ) + 'px;" title="' + title + '"><button type="button" id="dialog-close-button" autofocus><span class="screen-reader-text">' + wp.i18n.__( 'Close' ) + '</span></button><div id="plugin-information-scrollable"><div id="plugin-information-inner"><h2>' + header + '</h2>' + content + '</div></div><div id="plugin-information-footer">' + status.outerHTML + '</div></div>';
 
 			// Set initial focus on the "Close" button
 			closeButton = dialog.querySelector( '#dialog-close-button' );

--- a/styles/directory-integration.css
+++ b/styles/directory-integration.css
@@ -225,4 +225,8 @@
 	.cp-plugin-search-box .wp-filter-search {
 		width: 100%;
 	}
+
+	#plugin-information-footer {
+		height: 40px;
+	}
 }

--- a/styles/directory-integration.css
+++ b/styles/directory-integration.css
@@ -2,9 +2,8 @@
 	margin-bottom: 1em;
 }
 
-.cp-plugin-search-box {
+.cp-plugin-search-form {
 	float: right;
-	margin: -5em 0 0;
 }
 
 .plugin-install-tab .wp-header-end {
@@ -154,23 +153,23 @@
 	border: 2px solid #000;
 }
 
-#plugin-information-scrollable {
-	padding: 0 1.5em;
+#plugin-information-inner {
+	padding: 0 1.5em 60px;
 }
 
-#plugin-information-scrollable h2 {
+#plugin-information-inner h2 {
 	font-size: 2em;
 }
 
-#plugin-information-scrollable h4 {
+#plugin-information-inner h4 {
 	font-size: 1.2em;
 }
 
-#plugin-information-scrollable h5 {
+#plugin-information-inner h5 {
 	font-size: 1.1em;
 }
 
-#plugin-information-scrollable h6 {
+#plugin-information-inner h6 {
 	font-size: 1.05em;
 }
 
@@ -197,7 +196,6 @@
 
 #plugin-install-from-modal {
 	float: right;
-	margin-top: -2px;
 }
 
 #plugin-information-footer .cp-plugin-installed {
@@ -214,4 +212,17 @@
     .cp-plugin-actions .cp-plugin-installed {
 		height: unset;
     }
+}
+
+@media (max-width: 782px) {
+	.cp-plugin-search-form {
+		float: none;
+		clear: both;
+		width: 100%;
+		margin: 0 0 3em;
+	}
+
+	.cp-plugin-search-box .wp-filter-search {
+		width: 100%;
+	}
 }

--- a/styles/directory-integration.css
+++ b/styles/directory-integration.css
@@ -4,6 +4,7 @@
 
 .cp-plugin-search-form {
 	float: right;
+	margin: 1em 0;
 }
 
 .plugin-install-tab .wp-header-end {
@@ -157,19 +158,19 @@
 	padding: 0 1.5em 60px;
 }
 
-#plugin-information-inner h2 {
+#plugin-information-scrollable h2 {
 	font-size: 2em;
 }
 
-#plugin-information-inner h4 {
+#plugin-information-scrollable h4 {
 	font-size: 1.2em;
 }
 
-#plugin-information-inner h5 {
+#plugin-information-scrollable h5 {
 	font-size: 1.1em;
 }
 
-#plugin-information-inner h6 {
+#plugin-information-scrollable h6 {
 	font-size: 1.05em;
 }
 

--- a/styles/directory-integration.css
+++ b/styles/directory-integration.css
@@ -197,6 +197,7 @@
 
 #plugin-install-from-modal {
 	float: right;
+	margin-top: -2px;
 }
 
 #plugin-information-footer .cp-plugin-installed {
@@ -225,9 +226,5 @@
 
 	.cp-plugin-search-box .wp-filter-search {
 		width: 100%;
-	}
-
-	#plugin-information-footer {
-		height: 40px;
 	}
 }


### PR DESCRIPTION
### Description
This is a follow-up on Core tickets [#2331](https://github.com/ClassicPress/ClassicPress/pull/2331) and [#2322](https://github.com/ClassicPress/ClassicPress/pull/2322). But it's working independently, so backwards compatible.

It makes the search bar full width at the CP Plugins / CP Themes page in small screens (< 783px).

Also minor layout related change in the plugin/theme info modal. Not visible, but cleaner. This requires adding an extra container called `plugin-information-inner`.

### Search Form before
![CP Directory Plugin - before](https://github.com/user-attachments/assets/76a9520b-219b-427f-a70b-20aff72bac4e)

### Search Form after
![CP Directory Plugin - after](https://github.com/user-attachments/assets/168fadee-7a0b-414a-9bc9-f34685a79948)
