### PR TITLE
Fix Title tag in modal

### DIFF
--- a/scripts/directory-integration.js
+++ b/scripts/directory-integration.js
@@ -18,16 +18,16 @@ document.addEventListener( 'DOMContentLoaded', function() {
 	openers.forEach( function( opener ) {
 		opener.addEventListener( 'click', function( e ) {
 			var closeButton,
-				header = opener.closest( 'article' ).querySelector( 'h3' ).textContent,
+				header = opener.closest( 'article' ).querySelector( 'h3' ).textContent.trim(),
 				content = opener.closest( 'footer' ).dataset.content,
 				status = opener.nextElementSibling,
-				title = opener.closest( 'article' ).querySelector( 'h3' ).textContent ?
+				title = header ?
 					wp.i18n.sprintf(
-						// translators: %s: Plugin name.
-						wp.i18n.__( 'Plugin: %s' ),
-						opener.closest( 'article' ).querySelector( 'h3' ).textContent
+						// translators: %s: Plugin or Theme name.
+						wp.i18n.__( '%s Details' ),
+						header
 					) :
-					wp.i18n.__( 'Plugin details' );
+					wp.i18n.__( 'Details' );
 
 			e.preventDefault();
 			e.stopPropagation();


### PR DESCRIPTION
This PR fixes Issue #45. 
Removed "Plugin" from the title attribute, because modal is being used for CP themes as well.

## Before
<img width="818" height="360" alt="image" src="https://github.com/user-attachments/assets/06478b4a-2a34-48f2-bb14-1d87cad1b85d" />

## After
<img width="826" height="256" alt="image" src="https://github.com/user-attachments/assets/98410fd2-4013-4c55-a59d-21a6f576f947" />

